### PR TITLE
Update retryMax value in bicep-deploy action.yaml

### DIFF
--- a/.github/actions/bicep-deploy/action.yaml
+++ b/.github/actions/bicep-deploy/action.yaml
@@ -85,7 +85,7 @@ runs:
           }
 
           $retryCount = 0
-          $retryMax = 30
+          $retryMax = 5
           $initialRetryDelay = 20
           $retryDelayIncrement = 10
           $finalSuccess = $false


### PR DESCRIPTION
This pull request includes a small but significant change to the retry logic in the `bicep-deploy` GitHub Action. The change reduces the maximum number of retries from 30 to 5.

* [`.github/actions/bicep-deploy/action.yaml`](diffhunk://#diff-cc1b03c9e9d7fa081195aadb57199bbd2368652242047e50ac61a76e1586ce0eL88-R88): Reduced `$retryMax` from 30 to 5 to limit the number of retries in the deployment process.