### PR TITLE
Changed to vWAN

### DIFF
--- a/.github/actions/bicep-deploy/action.yaml
+++ b/.github/actions/bicep-deploy/action.yaml
@@ -85,7 +85,7 @@ runs:
           }
 
           $retryCount = 0
-          $retryMax = 30
+          $retryMax = 5
           $initialRetryDelay = 20
           $retryDelayIncrement = 10
           $finalSuccess = $false

--- a/.github/workflows/cd-template.yaml
+++ b/.github/workflows/cd-template.yaml
@@ -226,13 +226,13 @@ jobs:
           firstRunWhatIf: 'true'
           firstDeployment: '${{ env.firstDeployment }}'
           whatIfEnabled: 'true'
-      - name: 'What If: Hub (Hub-and-Spoke) Deployment'
+      - name: 'What If: Hub (VWAN) Deployment'
         uses: janegilring-demo/alz-mgmt-templates/.github/actions/bicep-deploy@main
         if: ${{ inputs.hub_and_spoke && !inputs.destroy }}
         with:
-          displayName: 'Hub (Hub-and-Spoke) Deployment'
-          templateFilePath: './infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep'
-          templateParametersFilePath: './config/custom-parameters/hubNetworking.parameters.all.json'
+          displayName: 'Hub (VWAN) Deployment'
+          templateFilePath: './infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep'
+          templateParametersFilePath: './config/custom-parameters/vwanConnectivity.parameters.all.json'
           managementGroupId: ''
           subscriptionId: '${{ env.CONNECTIVITY_SUBSCRIPTION_ID }}'
           resourceGroupName: '${{ env.CONNECTIVITY_RESOURCE_GROUP }}'
@@ -418,13 +418,13 @@ jobs:
           deploymentType: 'subscription'
           firstRunWhatIf: 'true'
           whatIfEnabled: 'false'
-      - name: 'Deploy: Hub (Hub-and-Spoke) Deployment'
+      - name: 'Deploy: Hub (VWAN) Deployment'
         uses: janegilring-demo/alz-mgmt-templates/.github/actions/bicep-deploy@main
         if: ${{ inputs.hub_and_spoke && !inputs.destroy }}
         with:
-          displayName: 'Hub (Hub-and-Spoke) Deployment'
-          templateFilePath: './infra-as-code/bicep/modules/hubNetworking/hubNetworking.bicep'
-          templateParametersFilePath: './config/custom-parameters/hubNetworking.parameters.all.json'
+          displayName: 'Hub (VWAN) Deployment'
+          templateFilePath: './infra-as-code/bicep/modules/vwanConnectivity/vwanConnectivity.bicep'
+          templateParametersFilePath: './config/custom-parameters/vwanConnectivity.parameters.all.json'
           managementGroupId: ''
           subscriptionId: '${{ env.CONNECTIVITY_SUBSCRIPTION_ID }}'
           resourceGroupName: '${{ env.CONNECTIVITY_RESOURCE_GROUP }}'


### PR DESCRIPTION
This pull request includes changes to the deployment configuration files to update the deployment strategy and retry logic. The most important changes involve modifying the retry parameters and updating the deployment templates from "Hub-and-Spoke" to "VWAN".

### Deployment Strategy Updates:
* [`.github/workflows/cd-template.yaml`](diffhunk://#diff-424de3d9cebe4a206a509ebc35c9d345cb53b79a9070d1cc434175c4cff99e3bL229-R235): Changed the deployment name and template paths from "Hub-and-Spoke" to "VWAN" for both "What If" and actual deployments. [[1]](diffhunk://#diff-424de3d9cebe4a206a509ebc35c9d345cb53b79a9070d1cc434175c4cff99e3bL229-R235) [[2]](diffhunk://#diff-424de3d9cebe4a206a509ebc35c9d345cb53b79a9070d1cc434175c4cff99e3bL421-R427)

### Retry Logic Adjustment:
* [`.github/actions/bicep-deploy/action.yaml`](diffhunk://#diff-cc1b03c9e9d7fa081195aadb57199bbd2368652242047e50ac61a76e1586ce0eL88-R88): Reduced the maximum number of retries from 30 to 5 to streamline the retry logic.